### PR TITLE
feat: add logging destination option

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -93,7 +93,11 @@ childCtx.log('Waiting for response to prepare');
 // ...
 ```
 
-**Note: NodeKit uses pino for logging but does not exposes any of it's API or configuration capabilities. However, we would like to add option for configuring pino little later, see [this issue](https://github.com/gravity-ui/nodekit/issues/5) for more details**.
+**Note: NodeKit uses pino for logging but does not exposes most of it's API or configuration capabilities. However, we would like to add option for configuring pino little later, see [this issue](https://github.com/gravity-ui/nodekit/issues/5) for more details**.
+
+### Logging destinations
+
+You can override default logs destination (stdout) with `appLoggingDestination` option which accepts [pino.Destination](https://github.com/pinojs/pino/blob/master/docs/api.md#destination). It allows to implement custom formatters for logs as well as custom transports for them. Currently, this option only works if devMode is set to false. If you have an usecase when you need this option alongside enabled dev mode, feel free to open an issue.
 
 ## Distributed tracing
 

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -3,9 +3,10 @@ import pino from 'pino';
 interface InitLoggerOptions {
     appName: string;
     devMode: boolean;
+    destination?: pino.DestinationStream;
 }
 
-export function initLogger({appName, devMode}: InitLoggerOptions) {
+export function initLogger({appName, devMode, destination}: InitLoggerOptions) {
     const transportConfig = devMode
         ? {
               target: 'pino-pretty',
@@ -17,7 +18,7 @@ export function initLogger({appName, devMode}: InitLoggerOptions) {
           }
         : undefined;
 
-    return pino({
+    const options = {
         name: appName,
         safe: true,
         leve: 'debug',
@@ -25,5 +26,11 @@ export function initLogger({appName, devMode}: InitLoggerOptions) {
             error: pino.stdSerializers.err,
         },
         transport: transportConfig,
-    });
+    };
+
+    if (destination && !devMode) {
+        return pino(options, destination);
+    } else {
+        return pino(options);
+    }
 }

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -66,6 +66,7 @@ export class NodeKit {
         this.logger = initLogger({
             appName: this.config.appName as string,
             devMode: appDevMode,
+            destination: this.config.appLoggingDestination,
         });
 
         const redactSensitiveQueryParams = prepareSensitiveQueryParamsRedacter(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import {pino} from 'pino';
+
 export interface AppConfig {
     appName?: string;
     appVersion?: string;
@@ -11,10 +13,13 @@ export interface AppConfig {
     nkDefaultSensitiveHeaders?: string[];
     nkDefaultHeadersWithSensitiveUrls?: string[];
     nkDefaultSensitiveQueryParams?: string[];
+
     appSensitiveKeys?: string[];
     appSensitiveHeaders?: string[];
     appHeadersWithSensitiveUrls?: string[];
     appSensitiveQueryParams?: string[];
+
+    appLoggingDestination?: pino.DestinationStream;
 
     appTracingEnabled?: boolean;
     appTracingServiceName?: string;


### PR DESCRIPTION
Adding new configuration option which allows using custom streams and formatters for pino output.

More info [here](https://github.com/gravity-ui/nodekit/blob/add-logging-destination/docs/contexts.md#logging-destinations).