### PR TITLE
feat: add ability to attach extra data to log lines

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -242,9 +242,13 @@ export class AppContext {
         return this.span?._spanContext?.toTraceId();
     }
 
-    // allow override extra logger data, after ctx already initialized (ex. to add traceId from ctx)
-    setLoggerExtra(extra: Dict) {
-        this.loggerExtra = extra;
+    // allow add extra logger data, after ctx already initialized (ex. to add traceId from ctx)
+    addLoggerExtra(key: string, value: unknown) {
+        this.loggerExtra = this.mergeExtra(this.loggerExtra, {[key]: value});
+    }
+
+    clearLoggerExtra() {
+        this.loggerExtra = {};
     }
 
     private prepareLogMessage(message: string) {

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -259,7 +259,7 @@ export class AppContext {
         return Object.keys(preparedExtra).length ? preparedExtra : undefined;
     }
 
-    private mergeExtra(extraParent?: Dict, extraCurrent?: Dict) {
+    private mergeExtra(extraParent: Dict | undefined, extraCurrent: Dict | undefined) {
         if (extraParent === undefined) {
             return extraCurrent;
         }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -87,6 +87,8 @@ export class AppContext {
                 childOf: params.parentSpanContext || params.parentContext?.span,
             });
             this.stats = params.parentContext.stats;
+
+            this.parentContext = params.parentContext;
         } else if (params.config && params.logger && params.tracer && params.utils) {
             this.appParams = {};
             this.config = params.config;
@@ -128,7 +130,7 @@ export class AppContext {
                 this.prepareLogMessage(message),
             );
         } else {
-            this.logger.error(this.prepareLogMessage(message));
+            this.logger.error(this.loggerExtra, this.prepareLogMessage(message));
         }
 
         this.span?.setTag(Tags.SAMPLING_PRIORITY, 1);
@@ -248,7 +250,7 @@ export class AppContext {
     }
 
     clearLoggerExtra() {
-        this.loggerExtra = {};
+        this.loggerExtra = Object.assign({}, this.parentContext?.loggerExtra);
     }
 
     private prepareLogMessage(message: string) {
@@ -264,9 +266,6 @@ export class AppContext {
     }
 
     private mergeExtra(extraParent: Dict | undefined, extraCurrent: Dict | undefined) {
-        if (extraParent === undefined) {
-            return extraCurrent;
-        }
         return Object.assign({}, extraParent, extraCurrent);
     }
 }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -251,7 +251,7 @@ export class AppContext {
         return `${this.loggerPrefix} ${message} ${this.loggerPostfix}`.trim();
     }
 
-    private prepareExtra(extra?: Dict) {
+    private prepareExtra(extra: Dict | undefined) {
         if (extra === undefined) {
             return extra;
         }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -117,8 +117,8 @@ export class AppContext {
             this.logger.error(
                 Object.assign(
                     {},
-                    extractErrorInfo(error),
                     this.prepareExtra(this.mergeExtra(this.loggerExtra, extra)),
+                    extractErrorInfo(error),
                 ),
                 this.prepareLogMessage(message),
             );

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -242,6 +242,11 @@ export class AppContext {
         return this.span?._spanContext?.toTraceId();
     }
 
+    // allow override extra logger data, after ctx already initialized (ex. to add traceId from ctx)
+    setLoggerExtra(extra: Dict) {
+        this.loggerExtra = extra;
+    }
+
     private prepareLogMessage(message: string) {
         return `${this.loggerPrefix} ${message} ${this.loggerPostfix}`.trim();
     }

--- a/src/tests/logging.test.ts
+++ b/src/tests/logging.test.ts
@@ -1,0 +1,132 @@
+import {NodeKit} from '..';
+
+const logger = {
+    write: jest.fn(),
+};
+
+test('check base logging system', () => {
+    const nodeKit = new NodeKit({config: {appLoggingDestination: logger}});
+
+    // log function
+    nodeKit.ctx.log('log info');
+    let log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({
+        msg: 'log info',
+        level: 30,
+    });
+
+    // logError function
+    nodeKit.ctx.logError('log error');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({
+        msg: 'log error',
+        level: 50,
+    });
+
+    // logError function with error object
+    const err = new Error('error object');
+
+    nodeKit.ctx.logError('log error with error object', err);
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({
+        msg: 'log error with error object',
+        level: 50,
+        err: {
+            message: 'error object',
+            type: 'Object',
+            stack: expect.stringContaining('Error: error object'),
+        },
+    });
+});
+
+test('check logging with extra data', () => {
+    const nodeKit = new NodeKit({config: {appLoggingDestination: logger}});
+
+    const extra = Math.random().toString();
+
+    // log function with extra param
+    nodeKit.ctx.log('log info', {extra});
+    let log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({extra});
+
+    // add extra data to ctx
+    const traceId = Math.random().toString();
+    nodeKit.ctx.addLoggerExtra('traceId', traceId);
+
+    // log function with extra ctx data
+    nodeKit.ctx.log('log info');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId});
+
+    // log function with extra param and extra ctx data
+    nodeKit.ctx.log('log info', {extra});
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId, extra});
+
+    // logError function with extra param and extra ctx data
+    nodeKit.ctx.logError('log error', new Error('err'), {extra});
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({
+        extra,
+        traceId,
+        level: 50,
+    });
+});
+
+test('check logging from nested ctx', () => {
+    const nodeKit = new NodeKit({config: {appLoggingDestination: logger}});
+
+    const traceId = Math.random().toString();
+    nodeKit.ctx.addLoggerExtra('traceId', traceId);
+
+    // log function from parent ctx
+    nodeKit.ctx.log('log info');
+    let log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId});
+
+    const ctxName = Math.random().toString();
+    const logPostfix = Math.random().toString();
+    const newCtx = nodeKit.ctx.create(ctxName, {loggerPostfix: logPostfix});
+
+    // log function from nested ctx
+    newCtx.log('log info');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId, msg: `[${ctxName}] log info ${logPostfix}`});
+
+    // log function from nested ctx with override data
+    const anotherTraceId = Math.random().toString();
+    newCtx.addLoggerExtra('traceId', anotherTraceId);
+
+    newCtx.log('log info');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId: anotherTraceId});
+
+    // log function from nested ctx with new data
+    newCtx.clearLoggerExtra();
+    newCtx.addLoggerExtra('anotherTraceId', anotherTraceId);
+
+    newCtx.log('log info');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({traceId, anotherTraceId});
+
+    // logError function from nested ctx with new data
+    newCtx.logError('log error');
+    log = JSON.parse(logger.write.mock.lastCall?.pop() || '{}');
+
+    expect(log).toMatchObject({
+        traceId,
+        anotherTraceId,
+        msg: `[${ctxName}] log error ${logPostfix}`,
+    });
+});


### PR DESCRIPTION
1. More strict error format, same as main log. Without new `{extra:..}` nested object
2. Feature for specify content logging extra data for add ability save context data for all logs (useful for expresskit request and response)
3. Fix types for logs. Extra object for pino logger may be empty or undefined. Not necessary processing it with `prepareExtra`

Maybe this is not breaking changes, please fix me

Concept at Expresskit lib
https://github.com/gravity-ui/expresskit/pull/47 