### PR TITLE
fix(context): check ctx status in abort listener

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -115,7 +115,9 @@ export class AppContext {
             );
 
             params.parentContext.abortSignal.addEventListener('abort', () => {
-                this.end();
+                if (!this.abortSignal.aborted) {
+                    this.end();
+                }
             });
 
             if (this.isTracingEnabled(this.tracer)) {


### PR DESCRIPTION
Make sure that current context was not ended before trying to close it on abort signal from the parent context.