### PR TITLE
perf: avoid redundant work in redactSensitiveHeaders on each call

### DIFF
--- a/src/lib/utils/redact-sensitive-headers.ts
+++ b/src/lib/utils/redact-sensitive-headers.ts
@@ -10,16 +10,15 @@ export default function prepareSensitiveHeadersRedacter(
     redactSensitiveQueryParams: (input: string) => string = (input) => input,
     isDevMode = false,
 ) {
+    const headersWithSensitiveUrlsLowered = headersWithSensitiveUrls.map((name) =>
+        name.toLowerCase(),
+    );
+    const redactSensitiveKeys = prepareSensitiveKeysRedacter(sensitiveHeaders);
+
     const redactSensitiveHeaders: SensitiveHeadersRedacter = (inputHeaders = {}) => {
         if (isDevMode) {
             return inputHeaders;
         }
-
-        const headersWithSensitiveUrlsLowered = headersWithSensitiveUrls.map((name) =>
-            name.toLowerCase(),
-        );
-
-        const redactSensitiveKeys = prepareSensitiveKeysRedacter(sensitiveHeaders);
 
         const result = redactSensitiveKeys(inputHeaders) as IncomingHttpHeaders;
 


### PR DESCRIPTION
## Problem

`prepareSensitiveHeadersRedacter` returns a closure (`redactSensitiveHeaders`) that is called on every incoming request. Inside that closure, two expensive operations were being repeated unnecessarily on each invocation:

1. `headersWithSensitiveUrls.map(name => name.toLowerCase())` — rebuilds the lowercased array every call
2. `prepareSensitiveKeysRedacter(sensitiveHeaders)` — creates a new redacter function with a new closure every call

Both inputs (`sensitiveHeaders`, `headersWithSensitiveUrls`) are fixed at the time `prepareSensitiveHeadersRedacter` is called and never change afterward.

## Fix

Move both computations to the outer factory function scope, so they run once at initialization rather than on every request.

## Test plan

- [x] All 67 existing unit tests pass (`npm test`)
- [x] Behaviour is identical — only timing of allocation changes, not results
