### PR TITLE
feat: support passing envFilePath to NodeKit constructor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,14 @@ To disable dotenv, pass an option to the constructor:
 const nodeKit = new NodeKit({disableDotEnv: true});
 ```
 
+You can also specify a custom path to the `.env` file:
+
+```typescript
+const nodeKit = new NodeKit({
+    envFilePath: '/custom/path/.env',
+});
+```
+
 ## Accessing configuration
 
 You can access resulting configuration via NodeKit class instance or using any context:

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -23,6 +23,7 @@ import type {tracing} from '@opentelemetry/sdk-node';
 
 interface InitOptions {
     disableDotEnv?: boolean;
+    envFilePath?: string;
     configsPath?: string;
     config?: AppConfig;
 }
@@ -44,7 +45,7 @@ export class NodeKit {
 
     constructor(options: InitOptions = {}) {
         if (!options.disableDotEnv) {
-            dotenv.config();
+            dotenv.config(options.envFilePath ? {path: options.envFilePath} : undefined);
         }
 
         const appInstallation = process.env.APP_INSTALLATION;

--- a/src/tests/dotenv.test.ts
+++ b/src/tests/dotenv.test.ts
@@ -1,0 +1,34 @@
+import * as dotenv from 'dotenv';
+import {NodeKit} from '..';
+
+jest.mock('dotenv');
+
+const mockedDotenv = jest.mocked(dotenv);
+
+beforeEach(() => {
+    mockedDotenv.config.mockClear();
+});
+
+describe('dotenv integration', () => {
+    test('should call dotenv.config by default', () => {
+        const nodekit = new NodeKit({config: {appTracingEnabled: false}});
+        expect(mockedDotenv.config).toHaveBeenCalledTimes(1);
+        expect(mockedDotenv.config).toHaveBeenCalledWith(undefined);
+        expect(nodekit.config).toBeDefined();
+    });
+
+    test('should not call dotenv.config when disableDotEnv is true', () => {
+        const nodekit = new NodeKit({disableDotEnv: true, config: {appTracingEnabled: false}});
+        expect(mockedDotenv.config).not.toHaveBeenCalled();
+        expect(nodekit.config).toBeDefined();
+    });
+
+    test('should pass envFilePath as path to dotenv.config', () => {
+        const nodekit = new NodeKit({
+            envFilePath: '/custom/.env',
+            config: {appTracingEnabled: false},
+        });
+        expect(mockedDotenv.config).toHaveBeenCalledWith({path: '/custom/.env'});
+        expect(nodekit.config).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds optional `envFilePath` field to `InitOptions` for specifying a custom `.env` file path
- Forwards the path to `dotenv.config({path})`, keeping the API minimal and migration-friendly
- When Node.js native `process.loadEnvFile(path)` becomes the target, the public API stays the same

Closes #116

## Test plan

- [x] Unit tests for `envFilePath` forwarding added
- [x] Verify existing dotenv behavior unchanged when `envFilePath` is not provided
- [x] Verify `disableDotEnv` still works