### PR TITLE
feat: bridge OTel Log Records into pino via appTracingLogsBridge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.13.3",
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.214.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.214.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.214.0",
         "@opentelemetry/propagator-jaeger": "^2.6.1",
+        "@opentelemetry/sdk-logs": "^0.214.0",
         "@opentelemetry/sdk-node": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.13.3",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.214.0",
+    "@opentelemetry/sdk-logs": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.214.0",

--- a/src/lib/tracing/init-tracing.ts
+++ b/src/lib/tracing/init-tracing.ts
@@ -8,6 +8,7 @@ import {NodeSDK, core, resources, tracing} from '@opentelemetry/sdk-node';
 import {ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION} from '@opentelemetry/semantic-conventions';
 import type {AppConfig} from '../../types';
 import {createNodekitDiagLogger} from './nodekit-diag-logger';
+import {PinoLogRecordProcessor} from './pino-log-record-processor';
 import type {NodeKitLogger} from '../logging';
 
 const textMapPropagator = new core.CompositePropagator({
@@ -31,6 +32,7 @@ export const initTracing = (config: AppConfig, logger: NodeKitLogger) => {
         appTracingSpanExporter,
         appTracingCollectorProtocol,
         appTracingDisableTLS,
+        appTracingLogsBridge,
     } = config;
 
     let tracingSpanExporter: tracing.SpanExporter;
@@ -61,6 +63,9 @@ export const initTracing = (config: AppConfig, logger: NodeKitLogger) => {
         textMapPropagator,
         sampler: appTracingSampler || new tracing.TraceIdRatioBasedSampler(1),
         instrumentations: appTracingInstrumentations,
+        ...(appTracingLogsBridge && {
+            logRecordProcessors: [new PinoLogRecordProcessor(logger)],
+        }),
     });
 
     if (appTracingDebugLogging) {

--- a/src/lib/tracing/init-tracing.ts
+++ b/src/lib/tracing/init-tracing.ts
@@ -10,6 +10,7 @@ import type {AppConfig} from '../../types';
 import {createNodekitDiagLogger} from './nodekit-diag-logger';
 import {PinoLogRecordProcessor} from './pino-log-record-processor';
 import type {NodeKitLogger} from '../logging';
+import {prepareSensitiveKeysRedacter} from '../utils/redact-sensitive-keys';
 
 const textMapPropagator = new core.CompositePropagator({
     propagators: [
@@ -64,7 +65,14 @@ export const initTracing = (config: AppConfig, logger: NodeKitLogger) => {
         sampler: appTracingSampler || new tracing.TraceIdRatioBasedSampler(1),
         instrumentations: appTracingInstrumentations,
         ...(appTracingLogsBridge && {
-            logRecordProcessors: [new PinoLogRecordProcessor(logger)],
+            logRecordProcessors: [
+                new PinoLogRecordProcessor(
+                    logger,
+                    prepareSensitiveKeysRedacter(
+                        config.nkDefaultSensitiveKeys?.concat(config.appSensitiveKeys ?? []),
+                    ),
+                ),
+            ],
         }),
     });
 

--- a/src/lib/tracing/init-tracing.ts
+++ b/src/lib/tracing/init-tracing.ts
@@ -33,7 +33,7 @@ export const initTracing = (config: AppConfig, logger: NodeKitLogger) => {
         appTracingSpanExporter,
         appTracingCollectorProtocol,
         appTracingDisableTLS,
-        appTracingLogsBridge,
+        experimentalAppTracingLogsBridge,
     } = config;
 
     let tracingSpanExporter: tracing.SpanExporter;
@@ -64,7 +64,7 @@ export const initTracing = (config: AppConfig, logger: NodeKitLogger) => {
         textMapPropagator,
         sampler: appTracingSampler || new tracing.TraceIdRatioBasedSampler(1),
         instrumentations: appTracingInstrumentations,
-        ...(appTracingLogsBridge && {
+        ...(experimentalAppTracingLogsBridge && {
             logRecordProcessors: [
                 new PinoLogRecordProcessor(
                     logger,

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -1,7 +1,9 @@
 import {SeverityNumber} from '@opentelemetry/api-logs';
 import type {SdkLogRecord} from '@opentelemetry/sdk-logs';
 
+import type {Dict} from '../../types';
 import type {NodeKitLogger} from '../logging';
+import type {SensitiveKeysRedacter} from '../utils/redact-sensitive-keys';
 
 type PinoLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
@@ -32,11 +34,13 @@ function severityToLevel(
     return 'error';
 }
 
-function bodyToString(body: SdkLogRecord['body']): string {
+function bodyToString(body: SdkLogRecord['body'], redact: SensitiveKeysRedacter): string {
     if (body === undefined || body === null) return '';
     if (typeof body === 'string') return body;
     try {
-        if (typeof body === 'object') return JSON.stringify(body);
+        if (typeof body === 'object') {
+            return JSON.stringify(redact(body as Dict));
+        }
     } catch {
         return '[Unserializable OTel log body]';
     }
@@ -57,26 +61,37 @@ function bodyToString(body: SdkLogRecord['body']): string {
  *  - `otelScope` – name of the instrumentation library that produced the record
  *  - `traceId` / `spanId` – when the record was emitted inside an active span
  *
- * Note: `otelScope`, `traceId` and `spanId` are written after spreading
- * logRecord.attributes, so they take precedence if the same keys appear in attributes.
+ * Note: `otelScope`, `traceId` and `spanId` take precedence over any OTel
+ * attributes with the same names.
  *
- * Note: should be enabled during NodeKit initialization, before any other code
- * initializes an OpenTelemetry LoggerProvider.
+ * Note: OTel attributes and object bodies are run through the same
+ * redactSensitiveKeys function as ctx.log(), so sensitive fields
+ * (e.g. authorization, password) are redacted before reaching stdout.
+ *
+ * Note: when this processor is active, env-based OTel Logs configuration
+ * (OTEL_LOGS_EXPORTER, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, etc.) is ignored
+ * by the SDK — explicit processors take priority over env configuration.
+ *
+ * Note: must be enabled during NodeKit initialization, before any other code
+ * registers an OpenTelemetry LoggerProvider — the global OTel provider can
+ * only be set once per process.
  */
 export class PinoLogRecordProcessor {
     private readonly logger: NodeKitLogger;
+    private readonly redact: SensitiveKeysRedacter;
 
-    constructor(logger: NodeKitLogger) {
+    constructor(logger: NodeKitLogger, redact: SensitiveKeysRedacter) {
         this.logger = logger;
+        this.redact = redact;
     }
 
     onEmit(logRecord: SdkLogRecord): void {
-        const message = bodyToString(logRecord.body) || logRecord.eventName || '';
+        const message = bodyToString(logRecord.body, this.redact) || logRecord.eventName || '';
 
         const level = severityToLevel(logRecord.severityNumber, logRecord.severityText);
 
         const extra: Record<string, unknown> = {
-            ...logRecord.attributes,
+            ...this.redact(logRecord.attributes as Dict),
             otelScope: logRecord.instrumentationScope.name,
         };
 

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -5,19 +5,41 @@ import type {NodeKitLogger} from '../logging';
 
 type PinoLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
-function severityToLevel(severity: SeverityNumber | undefined): PinoLevel {
-    if (severity === undefined) return 'info';
-    if (severity <= SeverityNumber.TRACE4) return 'trace';
-    if (severity <= SeverityNumber.DEBUG4) return 'debug';
-    if (severity <= SeverityNumber.INFO4) return 'info';
-    if (severity <= SeverityNumber.WARN4) return 'warn';
+function severityTextToLevel(severityText: string | undefined): PinoLevel | undefined {
+    const value = severityText?.toLowerCase();
+    if (!value) return undefined;
+    if (value.startsWith('trace')) return 'trace';
+    if (value.startsWith('debug')) return 'debug';
+    if (value.startsWith('info')) return 'info';
+    if (value.startsWith('warn')) return 'warn';
+    if (value.startsWith('error')) return 'error';
+    if (value.startsWith('fatal')) return 'error';
+    return undefined;
+}
+
+function severityToLevel(
+    severityNumber: SeverityNumber | undefined,
+    severityText: string | undefined,
+): PinoLevel {
+    // UNSPECIFIED (= 0) and undefined are both falsy — fall back to severityText, then 'info'
+    if (!severityNumber) {
+        return severityTextToLevel(severityText) ?? 'info';
+    }
+    if (severityNumber <= SeverityNumber.TRACE4) return 'trace';
+    if (severityNumber <= SeverityNumber.DEBUG4) return 'debug';
+    if (severityNumber <= SeverityNumber.INFO4) return 'info';
+    if (severityNumber <= SeverityNumber.WARN4) return 'warn';
     return 'error';
 }
 
 function bodyToString(body: SdkLogRecord['body']): string {
     if (body === undefined || body === null) return '';
     if (typeof body === 'string') return body;
-    if (typeof body === 'object') return JSON.stringify(body);
+    try {
+        if (typeof body === 'object') return JSON.stringify(body);
+    } catch {
+        return '[Unserializable OTel log body]';
+    }
     return String(body);
 }
 
@@ -34,13 +56,24 @@ function bodyToString(body: SdkLogRecord['body']): string {
  *  - all attributes from the original LogRecord (e.g. gen_ai.usage.input_tokens)
  *  - `otelScope` – name of the instrumentation library that produced the record
  *  - `traceId` / `spanId` – when the record was emitted inside an active span
+ *
+ * Note: `otelScope`, `traceId` and `spanId` are written after spreading
+ * logRecord.attributes, so they take precedence if the same keys appear in attributes.
+ *
+ * Note: should be enabled during NodeKit initialization, before any other code
+ * initializes an OpenTelemetry LoggerProvider.
  */
 export class PinoLogRecordProcessor {
-    constructor(private readonly logger: NodeKitLogger) {}
+    private readonly logger: NodeKitLogger;
+
+    constructor(logger: NodeKitLogger) {
+        this.logger = logger;
+    }
 
     onEmit(logRecord: SdkLogRecord): void {
-        const message = bodyToString(logRecord.body);
-        const level = severityToLevel(logRecord.severityNumber);
+        const message = bodyToString(logRecord.body) || logRecord.eventName || '';
+
+        const level = severityToLevel(logRecord.severityNumber, logRecord.severityText);
 
         const extra: Record<string, unknown> = {
             ...logRecord.attributes,

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -51,7 +51,7 @@ function bodyToString(body: SdkLogRecord['body'], redact: SensitiveKeysRedacter)
 
 /**
  * Bridges OTel Log Records emitted by instrumented libraries into pino.
- * See AppConfig.appTracingLogsBridge for full documentation.
+ * See AppConfig.experimentalAppTracingLogsBridge for full documentation.
  */
 export class PinoLogRecordProcessor {
     private readonly logger: NodeKitLogger;

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -48,33 +48,8 @@ function bodyToString(body: SdkLogRecord['body'], redact: SensitiveKeysRedacter)
 }
 
 /**
- * LogRecordProcessor that bridges OpenTelemetry Log Records into pino.
- *
- * OTel-instrumented libraries (e.g. @opentelemetry/instrumentation-openai) emit
- * log records via `logger.emit()`. Without a registered LoggerProvider those
- * records are silently dropped. This processor catches every emitted record and
- * writes it to the NodeKit pino logger so all OTel logs appear in the same
- * stdout stream as ctx.log() calls.
- *
- * Each log line includes:
- *  - all attributes from the original LogRecord (e.g. gen_ai.usage.input_tokens)
- *  - `otelScope` – name of the instrumentation library that produced the record
- *  - `traceId` / `spanId` – when the record was emitted inside an active span
- *
- * Note: `otelScope`, `traceId` and `spanId` take precedence over any OTel
- * attributes with the same names.
- *
- * Note: OTel attributes and object bodies are run through the same
- * redactSensitiveKeys function as ctx.log(), so sensitive fields
- * (e.g. authorization, password) are redacted before reaching stdout.
- *
- * Note: when this processor is active, env-based OTel Logs configuration
- * (OTEL_LOGS_EXPORTER, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, etc.) is ignored
- * by the SDK — explicit processors take priority over env configuration.
- *
- * Note: must be enabled during NodeKit initialization, before any other code
- * registers an OpenTelemetry LoggerProvider — the global OTel provider can
- * only be set once per process.
+ * Bridges OTel Log Records emitted by instrumented libraries into pino.
+ * See AppConfig.appTracingLogsBridge for full documentation.
  */
 export class PinoLogRecordProcessor {
     private readonly logger: NodeKitLogger;

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -1,0 +1,65 @@
+import {SeverityNumber} from '@opentelemetry/api-logs';
+import type {SdkLogRecord} from '@opentelemetry/sdk-logs';
+
+import type {NodeKitLogger} from '../logging';
+
+type PinoLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+function severityToLevel(severity: SeverityNumber | undefined): PinoLevel {
+    if (severity === undefined) return 'info';
+    if (severity <= SeverityNumber.TRACE4) return 'trace';
+    if (severity <= SeverityNumber.DEBUG4) return 'debug';
+    if (severity <= SeverityNumber.INFO4) return 'info';
+    if (severity <= SeverityNumber.WARN4) return 'warn';
+    return 'error';
+}
+
+function bodyToString(body: SdkLogRecord['body']): string {
+    if (body === undefined || body === null) return '';
+    if (typeof body === 'string') return body;
+    if (typeof body === 'object') return JSON.stringify(body);
+    return String(body);
+}
+
+/**
+ * LogRecordProcessor that bridges OpenTelemetry Log Records into pino.
+ *
+ * OTel-instrumented libraries (e.g. @opentelemetry/instrumentation-openai) emit
+ * log records via `logger.emit()`. Without a registered LoggerProvider those
+ * records are silently dropped. This processor catches every emitted record and
+ * writes it to the NodeKit pino logger so all OTel logs appear in the same
+ * stdout stream as ctx.log() calls.
+ *
+ * Each log line includes:
+ *  - all attributes from the original LogRecord (e.g. gen_ai.usage.input_tokens)
+ *  - `otelScope` – name of the instrumentation library that produced the record
+ *  - `traceId` / `spanId` – when the record was emitted inside an active span
+ */
+export class PinoLogRecordProcessor {
+    constructor(private readonly logger: NodeKitLogger) {}
+
+    onEmit(logRecord: SdkLogRecord): void {
+        const message = bodyToString(logRecord.body);
+        const level = severityToLevel(logRecord.severityNumber);
+
+        const extra: Record<string, unknown> = {
+            ...logRecord.attributes,
+            otelScope: logRecord.instrumentationScope.name,
+        };
+
+        if (logRecord.spanContext) {
+            extra.traceId = logRecord.spanContext.traceId;
+            extra.spanId = logRecord.spanContext.spanId;
+        }
+
+        this.logger[level](extra, message);
+    }
+
+    forceFlush(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    shutdown(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/src/lib/tracing/pino-log-record-processor.ts
+++ b/src/lib/tracing/pino-log-record-processor.ts
@@ -1,3 +1,5 @@
+import type {pino} from 'pino';
+
 import {SeverityNumber} from '@opentelemetry/api-logs';
 import type {SdkLogRecord} from '@opentelemetry/sdk-logs';
 
@@ -5,7 +7,7 @@ import type {Dict} from '../../types';
 import type {NodeKitLogger} from '../logging';
 import type {SensitiveKeysRedacter} from '../utils/redact-sensitive-keys';
 
-type PinoLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+type PinoLevel = Extract<pino.Level, keyof NodeKitLogger>;
 
 function severityTextToLevel(severityText: string | undefined): PinoLevel | undefined {
     const value = severityText?.toLowerCase();

--- a/src/tests/otel-logs-bridge.test.ts
+++ b/src/tests/otel-logs-bridge.test.ts
@@ -1,4 +1,4 @@
-import {SeverityNumber, type AnyValueMap, logs} from '@opentelemetry/api-logs';
+import {type AnyValueMap, SeverityNumber, logs} from '@opentelemetry/api-logs';
 import {LoggerProvider} from '@opentelemetry/sdk-logs';
 
 import {NodeKit, NodeKitLogger} from '..';
@@ -33,15 +33,14 @@ function makeLogger(): {logger: NodeKitLogger; calls: LogCall[]} {
     return {logger, calls};
 }
 
-/**
- * Build a minimal LogRecord and call processor.onEmit() directly.
- * Avoids global LoggerProvider state between tests.
- */
+// Build a minimal LogRecord and call processor.onEmit() directly.
+// Avoids global LoggerProvider state between tests.
 function buildAndEmit(
     processor: PinoLogRecordProcessor,
     opts: {
         body?: unknown;
         severityNumber?: SeverityNumber;
+        severityText?: string;
         attributes?: AnyValueMap;
         scope?: string;
     },
@@ -50,7 +49,8 @@ function buildAndEmit(
     const logger = provider.getLogger(opts.scope ?? 'test-scope');
     logger.emit({
         body: opts.body as string | undefined,
-        severityNumber: opts.severityNumber ?? SeverityNumber.INFO,
+        severityNumber: opts.severityNumber,
+        severityText: opts.severityText,
         attributes: opts.attributes,
     });
 }
@@ -92,12 +92,33 @@ describe('PinoLogRecordProcessor', () => {
         expect(calls.map((c) => c.level)).toEqual(cases.map(([, level]) => level));
     });
 
-    test('defaults to info when severityNumber is not set', () => {
+    test('UNSPECIFIED severity falls back to severityText', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {
+            body: 'msg',
+            severityNumber: SeverityNumber.UNSPECIFIED,
+            severityText: 'ERROR',
+        });
+
+        expect(calls[0]).toMatchObject({level: 'error'});
+    });
+
+    test('undefined severity falls back to severityText', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {body: 'msg', severityText: 'WARN'});
+
+        expect(calls[0]).toMatchObject({level: 'warn'});
+    });
+
+    test('defaults to info when both severityNumber and severityText are absent', () => {
         const {logger, calls} = makeLogger();
         const processor = new PinoLogRecordProcessor(logger);
 
         const provider = new LoggerProvider({processors: [processor]});
-        // emit without severityNumber
         provider.getLogger('test').emit({body: 'no severity'});
 
         expect(calls[0]).toMatchObject({level: 'info', message: 'no severity'});
@@ -135,6 +156,31 @@ describe('PinoLogRecordProcessor', () => {
         });
     });
 
+    test('otelScope overrides attribute with the same key', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {
+            body: 'msg',
+            scope: 'real-scope',
+            attributes: {otelScope: 'custom-from-attr'},
+        });
+
+        expect(calls[0].extra?.otelScope).toBe('real-scope');
+    });
+
+    test('uses eventName as message fallback when body is empty', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        const provider = new LoggerProvider({processors: [processor]});
+        provider.getLogger('test').emit({body: undefined, attributes: {'event.name': 'db.query'}});
+
+        // eventName is set via setEventName on the SdkLogRecord internally —
+        // here we verify empty body produces empty string (eventName path is internal)
+        expect(calls[0]).toBeDefined();
+    });
+
     test('serializes object body to JSON string', () => {
         const {logger, calls} = makeLogger();
         const processor = new PinoLogRecordProcessor(logger);
@@ -169,15 +215,13 @@ describe('PinoLogRecordProcessor', () => {
 // ── NodeKit integration ────────────────────────────────────────────────────
 
 describe('NodeKit appTracingLogsBridge', () => {
-    /**
-     * OTel global LoggerProvider can only be set once per process.
-     * We use a custom destination so pino writes to our mock — this must be
-     * the first (and only) NodeKit that registers the global provider.
-     */
+    // OTel global LoggerProvider can only be set once per process.
+    // We use a custom destination so pino writes to our mock — this must be
+    // the first (and only) NodeKit that registers the global provider.
     test('OTel log record appears in pino output when bridge is enabled', () => {
         const destination = {write: jest.fn()};
 
-        new NodeKit({
+        const nodekit = new NodeKit({
             config: {
                 appTracingEnabled: true,
                 appTracingLogsBridge: true,
@@ -185,17 +229,26 @@ describe('NodeKit appTracingLogsBridge', () => {
             },
         });
 
+        expect(nodekit).toBeDefined();
         expect(logs.getLoggerProvider().constructor.name).not.toBe('NoopLoggerProvider');
 
-        logs.getLoggerProvider().getLogger('test-lib').emit({
-            body: 'bridged message',
-            severityNumber: SeverityNumber.INFO,
-            attributes: {'custom.attr': 'value'},
-        });
+        logs.getLoggerProvider()
+            .getLogger('test-lib')
+            .emit({
+                body: 'bridged message',
+                severityNumber: SeverityNumber.INFO,
+                attributes: {'custom.attr': 'value'},
+            });
 
         const written = destination.write.mock.calls
             .flatMap((args: string[]) => args)
-            .map((raw: string) => { try { return JSON.parse(raw); } catch { return null; } })
+            .map((raw: string) => {
+                try {
+                    return JSON.parse(raw);
+                } catch {
+                    return null;
+                }
+            })
             .find((log: {msg?: string} | null) => log?.msg === 'bridged message');
 
         expect(written).toMatchObject({
@@ -206,13 +259,13 @@ describe('NodeKit appTracingLogsBridge', () => {
     });
 
     test('does not throw when appTracingLogsBridge is false', () => {
-        expect(() => {
-            new NodeKit({
-                config: {
-                    appTracingEnabled: true,
-                    appTracingLogsBridge: false,
-                },
-            });
-        }).not.toThrow();
+        const nodekit = new NodeKit({
+            config: {
+                appTracingEnabled: true,
+                appTracingLogsBridge: false,
+            },
+        });
+
+        expect(nodekit).toBeDefined();
     });
 });

--- a/src/tests/otel-logs-bridge.test.ts
+++ b/src/tests/otel-logs-bridge.test.ts
@@ -3,6 +3,7 @@ import {LoggerProvider} from '@opentelemetry/sdk-logs';
 
 import {NodeKit, NodeKitLogger} from '..';
 import {PinoLogRecordProcessor} from '../lib/tracing/pino-log-record-processor';
+import {prepareSensitiveKeysRedacter} from '../lib/utils/redact-sensitive-keys';
 import type {Dict} from '../types';
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -33,6 +34,8 @@ function makeLogger(): {logger: NodeKitLogger; calls: LogCall[]} {
     return {logger, calls};
 }
 
+const noopRedact = prepareSensitiveKeysRedacter([]);
+
 // Build a minimal LogRecord and call processor.onEmit() directly.
 // Avoids global LoggerProvider state between tests.
 function buildAndEmit(
@@ -41,6 +44,7 @@ function buildAndEmit(
         body?: unknown;
         severityNumber?: SeverityNumber;
         severityText?: string;
+        eventName?: string;
         attributes?: AnyValueMap;
         scope?: string;
     },
@@ -51,6 +55,7 @@ function buildAndEmit(
         body: opts.body as string | undefined,
         severityNumber: opts.severityNumber,
         severityText: opts.severityText,
+        eventName: opts.eventName,
         attributes: opts.attributes,
     });
 }
@@ -60,7 +65,7 @@ function buildAndEmit(
 describe('PinoLogRecordProcessor', () => {
     test('routes INFO log record to pino info', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {body: 'hello world', severityNumber: SeverityNumber.INFO});
 
@@ -83,7 +88,7 @@ describe('PinoLogRecordProcessor', () => {
         ];
 
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         for (const [severity] of cases) {
             buildAndEmit(processor, {body: `msg-${severity}`, severityNumber: severity});
@@ -94,7 +99,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('UNSPECIFIED severity falls back to severityText', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {
             body: 'msg',
@@ -107,7 +112,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('undefined severity falls back to severityText', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {body: 'msg', severityText: 'WARN'});
 
@@ -116,7 +121,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('defaults to info when both severityNumber and severityText are absent', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         const provider = new LoggerProvider({processors: [processor]});
         provider.getLogger('test').emit({body: 'no severity'});
@@ -126,7 +131,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('includes OTel attributes in extra', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {
             body: 'openai call',
@@ -144,7 +149,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('includes otelScope with instrumentation library name', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {
             body: 'msg',
@@ -158,7 +163,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('otelScope overrides attribute with the same key', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         buildAndEmit(processor, {
             body: 'msg',
@@ -171,19 +176,48 @@ describe('PinoLogRecordProcessor', () => {
 
     test('uses eventName as message fallback when body is empty', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
+
+        buildAndEmit(processor, {body: undefined, eventName: 'db.query'});
+
+        expect(calls[0].message).toBe('db.query');
+    });
+
+    test('redacts sensitive keys from attributes', () => {
+        const {logger, calls} = makeLogger();
+        const redact = prepareSensitiveKeysRedacter(['authorization', 'password']);
+        const processor = new PinoLogRecordProcessor(logger, redact);
+
+        buildAndEmit(processor, {
+            body: 'request',
+            attributes: {
+                authorization: 'Bearer secret-token',
+                password: 'p@ssw0rd',
+                'gen_ai.usage.input_tokens': 512,
+            },
+        });
+
+        expect(calls[0].extra).toMatchObject({
+            authorization: '[REDACTED]',
+            password: '[REDACTED]',
+            'gen_ai.usage.input_tokens': 512,
+        });
+    });
+
+    test('redacts sensitive keys from object body', () => {
+        const {logger, calls} = makeLogger();
+        const redact = prepareSensitiveKeysRedacter(['password']);
+        const processor = new PinoLogRecordProcessor(logger, redact);
 
         const provider = new LoggerProvider({processors: [processor]});
-        provider.getLogger('test').emit({body: undefined, attributes: {'event.name': 'db.query'}});
+        provider.getLogger('test').emit({body: {user: 'alice', password: 'secret'}});
 
-        // eventName is set via setEventName on the SdkLogRecord internally —
-        // here we verify empty body produces empty string (eventName path is internal)
-        expect(calls[0]).toBeDefined();
+        expect(calls[0].message).toBe('{"user":"alice","password":"[REDACTED]"}');
     });
 
     test('serializes object body to JSON string', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         const provider = new LoggerProvider({processors: [processor]});
         provider.getLogger('test').emit({body: {event: 'request', status: 200}});
@@ -193,7 +227,7 @@ describe('PinoLogRecordProcessor', () => {
 
     test('handles undefined body gracefully', () => {
         const {logger, calls} = makeLogger();
-        const processor = new PinoLogRecordProcessor(logger);
+        const processor = new PinoLogRecordProcessor(logger, noopRedact);
 
         const provider = new LoggerProvider({processors: [processor]});
         provider.getLogger('test').emit({body: undefined});
@@ -203,12 +237,16 @@ describe('PinoLogRecordProcessor', () => {
 
     test('forceFlush resolves immediately', async () => {
         const {logger} = makeLogger();
-        await expect(new PinoLogRecordProcessor(logger).forceFlush()).resolves.toBeUndefined();
+        await expect(
+            new PinoLogRecordProcessor(logger, noopRedact).forceFlush(),
+        ).resolves.toBeUndefined();
     });
 
     test('shutdown resolves immediately', async () => {
         const {logger} = makeLogger();
-        await expect(new PinoLogRecordProcessor(logger).shutdown()).resolves.toBeUndefined();
+        await expect(
+            new PinoLogRecordProcessor(logger, noopRedact).shutdown(),
+        ).resolves.toBeUndefined();
     });
 });
 

--- a/src/tests/otel-logs-bridge.test.ts
+++ b/src/tests/otel-logs-bridge.test.ts
@@ -6,8 +6,6 @@ import {PinoLogRecordProcessor} from '../lib/tracing/pino-log-record-processor';
 import {prepareSensitiveKeysRedacter} from '../lib/utils/redact-sensitive-keys';
 import type {Dict} from '../types';
 
-// ── helpers ────────────────────────────────────────────────────────────────
-
 type LogCall = {level: string; extra: Dict | undefined; message: string};
 
 function makeLogger(): {logger: NodeKitLogger; calls: LogCall[]} {
@@ -36,8 +34,7 @@ function makeLogger(): {logger: NodeKitLogger; calls: LogCall[]} {
 
 const noopRedact = prepareSensitiveKeysRedacter([]);
 
-// Build a minimal LogRecord and call processor.onEmit() directly.
-// Avoids global LoggerProvider state between tests.
+// Emits a log record through a local LoggerProvider, avoiding global OTel state.
 function buildAndEmit(
     processor: PinoLogRecordProcessor,
     opts: {
@@ -59,8 +56,6 @@ function buildAndEmit(
         attributes: opts.attributes,
     });
 }
-
-// ── PinoLogRecordProcessor unit tests ─────────────────────────────────────
 
 describe('PinoLogRecordProcessor', () => {
     test('routes INFO log record to pino info', () => {
@@ -249,8 +244,6 @@ describe('PinoLogRecordProcessor', () => {
         ).resolves.toBeUndefined();
     });
 });
-
-// ── NodeKit integration ────────────────────────────────────────────────────
 
 describe('NodeKit appTracingLogsBridge', () => {
     // OTel global LoggerProvider can only be set once per process.

--- a/src/tests/otel-logs-bridge.test.ts
+++ b/src/tests/otel-logs-bridge.test.ts
@@ -245,7 +245,7 @@ describe('PinoLogRecordProcessor', () => {
     });
 });
 
-describe('NodeKit appTracingLogsBridge', () => {
+describe('NodeKit experimentalAppTracingLogsBridge', () => {
     // OTel global LoggerProvider can only be set once per process.
     // We use a custom destination so pino writes to our mock — this must be
     // the first (and only) NodeKit that registers the global provider.
@@ -255,7 +255,7 @@ describe('NodeKit appTracingLogsBridge', () => {
         const nodekit = new NodeKit({
             config: {
                 appTracingEnabled: true,
-                appTracingLogsBridge: true,
+                experimentalAppTracingLogsBridge: true,
                 appLoggingDestination: destination,
             },
         });
@@ -289,11 +289,11 @@ describe('NodeKit appTracingLogsBridge', () => {
         });
     });
 
-    test('does not throw when appTracingLogsBridge is false', () => {
+    test('does not throw when experimentalAppTracingLogsBridge is false', () => {
         const nodekit = new NodeKit({
             config: {
                 appTracingEnabled: true,
-                appTracingLogsBridge: false,
+                experimentalAppTracingLogsBridge: false,
             },
         });
 

--- a/src/tests/otel-logs-bridge.test.ts
+++ b/src/tests/otel-logs-bridge.test.ts
@@ -1,0 +1,218 @@
+import {SeverityNumber, type AnyValueMap, logs} from '@opentelemetry/api-logs';
+import {LoggerProvider} from '@opentelemetry/sdk-logs';
+
+import {NodeKit, NodeKitLogger} from '..';
+import {PinoLogRecordProcessor} from '../lib/tracing/pino-log-record-processor';
+import type {Dict} from '../types';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+type LogCall = {level: string; extra: Dict | undefined; message: string};
+
+function makeLogger(): {logger: NodeKitLogger; calls: LogCall[]} {
+    const calls: LogCall[] = [];
+
+    function record(level: string) {
+        return (msgOrExtra: string | Dict | undefined, msg?: string) => {
+            calls.push({
+                level,
+                extra: typeof msgOrExtra === 'object' ? (msgOrExtra as Dict) : undefined,
+                message: msg ?? (msgOrExtra as string),
+            });
+        };
+    }
+
+    const logger: NodeKitLogger = {
+        trace: record('trace'),
+        debug: record('debug'),
+        info: record('info'),
+        warn: record('warn'),
+        error: record('error'),
+    };
+
+    return {logger, calls};
+}
+
+/**
+ * Build a minimal LogRecord and call processor.onEmit() directly.
+ * Avoids global LoggerProvider state between tests.
+ */
+function buildAndEmit(
+    processor: PinoLogRecordProcessor,
+    opts: {
+        body?: unknown;
+        severityNumber?: SeverityNumber;
+        attributes?: AnyValueMap;
+        scope?: string;
+    },
+) {
+    const provider = new LoggerProvider({processors: [processor]});
+    const logger = provider.getLogger(opts.scope ?? 'test-scope');
+    logger.emit({
+        body: opts.body as string | undefined,
+        severityNumber: opts.severityNumber ?? SeverityNumber.INFO,
+        attributes: opts.attributes,
+    });
+}
+
+// ── PinoLogRecordProcessor unit tests ─────────────────────────────────────
+
+describe('PinoLogRecordProcessor', () => {
+    test('routes INFO log record to pino info', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {body: 'hello world', severityNumber: SeverityNumber.INFO});
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({level: 'info', message: 'hello world'});
+    });
+
+    test('maps all severity levels correctly', () => {
+        const cases: [SeverityNumber, string][] = [
+            [SeverityNumber.TRACE, 'trace'],
+            [SeverityNumber.TRACE4, 'trace'],
+            [SeverityNumber.DEBUG, 'debug'],
+            [SeverityNumber.DEBUG4, 'debug'],
+            [SeverityNumber.INFO, 'info'],
+            [SeverityNumber.INFO4, 'info'],
+            [SeverityNumber.WARN, 'warn'],
+            [SeverityNumber.WARN4, 'warn'],
+            [SeverityNumber.ERROR, 'error'],
+            [SeverityNumber.FATAL, 'error'],
+        ];
+
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        for (const [severity] of cases) {
+            buildAndEmit(processor, {body: `msg-${severity}`, severityNumber: severity});
+        }
+
+        expect(calls.map((c) => c.level)).toEqual(cases.map(([, level]) => level));
+    });
+
+    test('defaults to info when severityNumber is not set', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        const provider = new LoggerProvider({processors: [processor]});
+        // emit without severityNumber
+        provider.getLogger('test').emit({body: 'no severity'});
+
+        expect(calls[0]).toMatchObject({level: 'info', message: 'no severity'});
+    });
+
+    test('includes OTel attributes in extra', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {
+            body: 'openai call',
+            attributes: {
+                'gen_ai.usage.input_tokens': 512,
+                'gen_ai.response.model': 'gpt-4o',
+            },
+        });
+
+        expect(calls[0].extra).toMatchObject({
+            'gen_ai.usage.input_tokens': 512,
+            'gen_ai.response.model': 'gpt-4o',
+        });
+    });
+
+    test('includes otelScope with instrumentation library name', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        buildAndEmit(processor, {
+            body: 'msg',
+            scope: '@opentelemetry/instrumentation-openai',
+        });
+
+        expect(calls[0].extra).toMatchObject({
+            otelScope: '@opentelemetry/instrumentation-openai',
+        });
+    });
+
+    test('serializes object body to JSON string', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        const provider = new LoggerProvider({processors: [processor]});
+        provider.getLogger('test').emit({body: {event: 'request', status: 200}});
+
+        expect(calls[0].message).toBe('{"event":"request","status":200}');
+    });
+
+    test('handles undefined body gracefully', () => {
+        const {logger, calls} = makeLogger();
+        const processor = new PinoLogRecordProcessor(logger);
+
+        const provider = new LoggerProvider({processors: [processor]});
+        provider.getLogger('test').emit({body: undefined});
+
+        expect(calls[0].message).toBe('');
+    });
+
+    test('forceFlush resolves immediately', async () => {
+        const {logger} = makeLogger();
+        await expect(new PinoLogRecordProcessor(logger).forceFlush()).resolves.toBeUndefined();
+    });
+
+    test('shutdown resolves immediately', async () => {
+        const {logger} = makeLogger();
+        await expect(new PinoLogRecordProcessor(logger).shutdown()).resolves.toBeUndefined();
+    });
+});
+
+// ── NodeKit integration ────────────────────────────────────────────────────
+
+describe('NodeKit appTracingLogsBridge', () => {
+    /**
+     * OTel global LoggerProvider can only be set once per process.
+     * We use a custom destination so pino writes to our mock — this must be
+     * the first (and only) NodeKit that registers the global provider.
+     */
+    test('OTel log record appears in pino output when bridge is enabled', () => {
+        const destination = {write: jest.fn()};
+
+        new NodeKit({
+            config: {
+                appTracingEnabled: true,
+                appTracingLogsBridge: true,
+                appLoggingDestination: destination,
+            },
+        });
+
+        expect(logs.getLoggerProvider().constructor.name).not.toBe('NoopLoggerProvider');
+
+        logs.getLoggerProvider().getLogger('test-lib').emit({
+            body: 'bridged message',
+            severityNumber: SeverityNumber.INFO,
+            attributes: {'custom.attr': 'value'},
+        });
+
+        const written = destination.write.mock.calls
+            .flatMap((args: string[]) => args)
+            .map((raw: string) => { try { return JSON.parse(raw); } catch { return null; } })
+            .find((log: {msg?: string} | null) => log?.msg === 'bridged message');
+
+        expect(written).toMatchObject({
+            msg: 'bridged message',
+            otelScope: 'test-lib',
+            'custom.attr': 'value',
+        });
+    });
+
+    test('does not throw when appTracingLogsBridge is false', () => {
+        expect(() => {
+            new NodeKit({
+                config: {
+                    appTracingEnabled: true,
+                    appTracingLogsBridge: false,
+                },
+            });
+        }).not.toThrow();
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,10 @@ export interface AppConfig {
      * Note: `otelScope`, `traceId` and `spanId` take precedence over any OTel
      * attributes with the same names.
      *
+     * Note: when enabled, env-based OTel Logs configuration is ignored by the SDK
+     * (OTEL_LOGS_EXPORTER, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, etc.) — explicit
+     * processors take priority over env configuration.
+     *
      * Note: must be enabled during NodeKit initialization, before any other code
      * registers an OpenTelemetry LoggerProvider — the global OTel provider can
      * only be set once per process.

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,13 @@ export interface AppConfig {
      * Each bridged log line contains all original OTel attributes plus
      * `otelScope`, `traceId` and `spanId` fields.
      *
+     * Note: `otelScope`, `traceId` and `spanId` take precedence over any OTel
+     * attributes with the same names.
+     *
+     * Note: must be enabled during NodeKit initialization, before any other code
+     * registers an OpenTelemetry LoggerProvider — the global OTel provider can
+     * only be set once per process.
+     *
      * @default false
      */
     appTracingLogsBridge?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,20 @@ export interface AppConfig {
      * @default undefined
      */
     appTracingDisableTLS?: boolean | undefined;
+    /**
+     * Bridge OpenTelemetry Log Records into pino.
+     *
+     * When enabled, a {@link PinoLogRecordProcessor} is registered as the global
+     * OTel LoggerProvider. Log records emitted by OTel-instrumented libraries
+     * (e.g. `@opentelemetry/instrumentation-openai`) will be written to the
+     * NodeKit pino logger instead of being silently dropped.
+     *
+     * Each bridged log line contains all original OTel attributes plus
+     * `otelScope`, `traceId` and `spanId` fields.
+     *
+     * @default false
+     */
+    appTracingLogsBridge?: boolean;
 
     appTelemetryChHost?: string;
     appTelemetryChPort?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface AppConfig {
     /**
      * Bridge OpenTelemetry Log Records into pino.
      *
-     * When enabled, a {@link PinoLogRecordProcessor} is registered as the global
+     * When enabled, a PinoLogRecordProcessor is registered as the global
      * OTel LoggerProvider. Log records emitted by OTel-instrumented libraries
      * (e.g. `@opentelemetry/instrumentation-openai`) will be written to the
      * NodeKit pino logger instead of being silently dropped.

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,10 @@ export interface AppConfig {
      */
     appTracingDisableTLS?: boolean | undefined;
     /**
-     * Bridge OpenTelemetry Log Records into pino.
+     * Experimental: bridge OpenTelemetry Log Records into pino.
+     *
+     * This option may be removed or changed in future versions without a
+     * backwards-compatible migration path.
      *
      * When enabled, a PinoLogRecordProcessor is registered as the global
      * OTel LoggerProvider. Log records emitted by OTel-instrumented libraries
@@ -94,7 +97,7 @@ export interface AppConfig {
      *
      * @default false
      */
-    appTracingLogsBridge?: boolean;
+    experimentalAppTracingLogsBridge?: boolean;
 
     appTelemetryChHost?: string;
     appTelemetryChPort?: string;


### PR DESCRIPTION
## Problem

OTel-instrumented libraries (e.g. `@opentelemetry/instrumentation-openai`) emit log records via `logger.emit()` from `@opentelemetry/api-logs`. Without a registered global `LoggerProvider`, these records are silently dropped — token counts, model names, finish reasons and other diagnostics never appear anywhere.

## Solution

Add `appTracingLogsBridge: true` config option that registers a `PinoLogRecordProcessor` as the global OTel `LoggerProvider`. Every OTel Log Record emitted by third-party libraries is bridged into the NodeKit pino logger, appearing in the same stdout stream as `ctx.log()` calls.

This approach requires no infrastructure changes — no separate OTLP logs endpoint, no extra Unified Agent port, no changes to existing log aggregation.

## Usage

```ts
new NodeKit({
    config: {
        appTracingEnabled: true,
        appTracingLogsBridge: true,
    }
});
```

Log line produced by `@opentelemetry/instrumentation-openai`:

```json
{
  "level": "info",
  "msg": "OpenAI chat completion",
  "otelScope": "@opentelemetry/instrumentation-openai",
  "gen_ai.usage.input_tokens": 512,
  "gen_ai.usage.output_tokens": 128,
  "gen_ai.response.model": "gpt-4o",
  "traceId": "a1b2c3d4...",
  "spanId": "e5f6a1b2..."
}
```
