### PR TITLE
chore: add conventional commits check for PR titles

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -13,6 +13,6 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -9,6 +9,9 @@ jobs:
   check-pr-title:
     name: Check PR Title (Conventional Commits)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,0 +1,15 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    name: Check PR Title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,18 +1,37 @@
-name: PR Title Check
+name: PR Title
 
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
     branches: [main]
-    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
 
 jobs:
-  check-pr-title:
-    name: Check PR Title (Conventional Commits)
+  conventional-commits:
+    name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.


### PR DESCRIPTION
## Problem

PRs merged into `main` without a [Conventional Commits](https://www.conventionalcommits.org/) title don't trigger a new release — `gravity-ui/release-action` relies on conventional commit messages to bump the version and generate the changelog.

## Solution

Add a GitHub Actions workflow that validates the PR title against the Conventional Commits spec using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).

The check runs on every PR targeting `main` whenever the PR is opened, edited, or synchronized.

## Supported types

`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
