### PR TITLE
feat: add shutdownHandler timeout

### DIFF
--- a/src/lib/base-config.ts
+++ b/src/lib/base-config.ts
@@ -5,5 +5,5 @@ export const NODEKIT_BASE_CONFIG: AppConfig = {
     nkDefaultSensitiveHeaders: ['authorization', 'cookie', 'set-cookie', 'password'],
     nkDefaultHeadersWithSensitiveUrls: ['referer'],
     nkDefaultSensitiveQueryParams: [],
-    appShutdownHandlersTimeout: 20000,
+    nkDefaultShutdownTimeout: 20000,
 };

--- a/src/lib/base-config.ts
+++ b/src/lib/base-config.ts
@@ -5,4 +5,5 @@ export const NODEKIT_BASE_CONFIG: AppConfig = {
     nkDefaultSensitiveHeaders: ['authorization', 'cookie', 'set-cookie', 'password'],
     nkDefaultHeadersWithSensitiveUrls: ['referer'],
     nkDefaultSensitiveQueryParams: [],
+    appShutdownHandlersTimeout: 20000,
 };

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -138,7 +138,7 @@ export class NodeKit {
     private setupShutdownSignals() {
         const signals = ['SIGTERM', 'SIGINT'] as const;
 
-        const timeout = this.config.appShutdownHandlersTimeout;
+        const timeout = this.config.appShutdownTimeout ?? this.config.nkDefaultShutdownTimeout;
         const isTimeoutEnabled =
             typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0;
 

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -138,6 +138,10 @@ export class NodeKit {
     private setupShutdownSignals() {
         const signals = ['SIGTERM', 'SIGINT'] as const;
 
+        const timeout = this.config.appShutdownHandlersTimeout;
+        const isTimeoutEnabled =
+            typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0;
+
         const handleSignal: ShutdownHandler = (signal) => {
             signals.forEach((signalName) => process.off(signalName, handleSignal));
 
@@ -152,7 +156,21 @@ export class NodeKit {
                 });
             });
 
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            if (isTimeoutEnabled) {
+                timeoutId = setTimeout(() => {
+                    this.ctx.logError(
+                        `Shutdown handlers did not complete within ${timeout}ms, forcing exit`,
+                    );
+                    this.ctx.end();
+                    process.exit(1);
+                }, timeout);
+            }
+
             Promise.allSettled(promises).then(() => {
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
+                }
                 this.ctx.end();
                 process.exit(code);
             });

--- a/src/tests/shutdown-timeout.test.ts
+++ b/src/tests/shutdown-timeout.test.ts
@@ -1,0 +1,89 @@
+import {AppConfig, NodeKit} from '..';
+
+const setupNodeKit = (config: AppConfig = {}) => {
+    const logger = {
+        write: jest.fn(),
+    };
+
+    const nodekit = new NodeKit({config: {appLoggingDestination: logger, ...config}});
+
+    return {nodekit, logger};
+};
+
+describe('shutdown timeout configuration', () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    afterEach(() => {
+        exitSpy.mockClear();
+        jest.useRealTimers();
+    });
+
+    test('appShutdownTimeout takes priority over nkDefaultShutdownTimeout', () => {
+        jest.useFakeTimers();
+
+        const {nodekit} = setupNodeKit({appShutdownTimeout: 100});
+
+        nodekit.addShutdownHandler(() => new Promise(() => {}));
+        process.emit('SIGTERM', 'SIGTERM');
+
+        jest.advanceTimersByTime(99);
+        expect(exitSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    test('falls back to nkDefaultShutdownTimeout when appShutdownTimeout is absent', () => {
+        jest.useFakeTimers();
+
+        const {nodekit} = setupNodeKit({nkDefaultShutdownTimeout: 200});
+
+        nodekit.addShutdownHandler(() => new Promise(() => {}));
+        process.emit('SIGTERM', 'SIGTERM');
+
+        jest.advanceTimersByTime(199);
+        expect(exitSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    test('exits with code 0 when handlers complete before timeout', async () => {
+        jest.useFakeTimers();
+
+        const {nodekit} = setupNodeKit({appShutdownTimeout: 1000});
+
+        nodekit.addShutdownHandler(() => Promise.resolve());
+        process.emit('SIGTERM', 'SIGTERM');
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    test('exits with code 1 when handlers throw errors', async () => {
+        jest.useFakeTimers();
+
+        const {nodekit} = setupNodeKit({appShutdownTimeout: 1000});
+
+        nodekit.addShutdownHandler(() => Promise.reject(new Error('handler failed')));
+        process.emit('SIGTERM', 'SIGTERM');
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    test('force-exits with code 1 when handlers hang past timeout', () => {
+        jest.useFakeTimers();
+
+        const {nodekit} = setupNodeKit({appShutdownTimeout: 500});
+
+        nodekit.addShutdownHandler(() => new Promise(() => {}));
+        process.emit('SIGTERM', 'SIGTERM');
+
+        jest.advanceTimersByTime(500);
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,13 @@ export interface AppConfig {
     nkDefaultHeadersWithSensitiveUrls?: string[];
     nkDefaultSensitiveQueryParams?: string[];
 
+    /**
+     * Default timeout for shutdown handlers in milliseconds.
+     * Used when appShutdownTimeout is not specified.
+     * @default 20000
+     */
+    nkDefaultShutdownTimeout?: number;
+
     appSensitiveKeys?: string[];
     appSensitiveHeaders?: string[];
     appHeadersWithSensitiveUrls?: string[];
@@ -110,7 +117,12 @@ export interface AppConfig {
 
     /**
      * Timeout for shutdown handlers in milliseconds.
-     * @default 20000
+     * Overrides nkDefaultShutdownTimeout when specified.
+     */
+    appShutdownTimeout?: number;
+
+    /**
+     * @deprecated Use appShutdownTimeout or nkDefaultShutdownTimeout instead.
      */
     appShutdownHandlersTimeout?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,12 @@ export interface AppConfig {
     appTelemetryChBatchSize?: number;
     appTelemetryChBacklogSize?: number;
     appTelemetryChMirrorToLogs?: boolean;
+
+    /**
+     * Timeout for shutdown handlers in milliseconds.
+     * @default 20000
+     */
+    appShutdownHandlersTimeout?: number;
 }
 
 export interface AppContextParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,11 +120,6 @@ export interface AppConfig {
      * Overrides nkDefaultShutdownTimeout when specified.
      */
     appShutdownTimeout?: number;
-
-    /**
-     * @deprecated Use appShutdownTimeout or nkDefaultShutdownTimeout instead.
-     */
-    appShutdownHandlersTimeout?: number;
 }
 
 export interface AppContextParams {


### PR DESCRIPTION
Description:

When the process receives SIGTERM or SIGINT, all registered shutdown handlers are executed. However, if one of these handlers hangs (e.g., due to an infinite loop, deadlock, or waiting for an unavailable resource), it can block the graceful shutdown process indefinitely.

This forces the orchestrator (Kubernetes, systemd, etc.) to eventually send SIGKILL, which terminates the process immediately without giving other handlers a chance to clean up properly. This can lead to resource leaks, corrupted state, or incomplete operations.

Proposed solution:

Introduce a configurable timeout for shutdown handlers (e.g., 20 seconds by default). If handlers do not complete within this time, the process should be forcefully terminated (with exit code 1 after calling ctx.end()), preventing a single misbehaving handler from blocking the entire shutdown process.

Setting the timeout to 0 or Infinity should restore the current behavior (wait indefinitely).