### PR TITLE
feat: add csrf token to the list of sensitiveHeaders

### DIFF
--- a/src/lib/base-config.ts
+++ b/src/lib/base-config.ts
@@ -2,7 +2,13 @@ import {AppConfig} from '../types';
 
 export const NODEKIT_BASE_CONFIG: AppConfig = {
     nkDefaultSensitiveKeys: ['authorization', 'cookie', 'set-cookie', 'password'],
-    nkDefaultSensitiveHeaders: ['authorization', 'cookie', 'set-cookie', 'password'],
+    nkDefaultSensitiveHeaders: [
+        'authorization',
+        'cookie',
+        'set-cookie',
+        'password',
+        'x-csrf-token',
+    ],
     nkDefaultHeadersWithSensitiveUrls: ['referer'],
     nkDefaultSensitiveQueryParams: [],
 };

--- a/src/lib/base-config.ts
+++ b/src/lib/base-config.ts
@@ -8,6 +8,7 @@ export const NODEKIT_BASE_CONFIG: AppConfig = {
         'set-cookie',
         'password',
         'x-csrf-token',
+        'x-xsrf-token',
     ],
     nkDefaultHeadersWithSensitiveUrls: ['referer'],
     nkDefaultSensitiveQueryParams: [],


### PR DESCRIPTION
**Problem:**
A CSRF token is considered sensitive information, even if its impact is somewhat limited compared to a password or API key. If exposed in logs (e.g., debug logs, access logs, it can increase the attack surface.

**Proposed solution**
Mask CSRF tokens in all log outputs