### PR TITLE
feat: transform result of DynamicConfigPoller

### DIFF
--- a/src/lib/dynamic-config-poller.ts
+++ b/src/lib/dynamic-config-poller.ts
@@ -11,6 +11,11 @@ export interface DynamicConfigSetup {
     headers?: Record<string, string>;
     /** dynamic headers */
     dynamicHeaders?: Record<string, () => Promise<string>>;
+    /**
+     * Transform raw response data into the stored config value.
+     * Use this to apply defaults, remap fields, or coerce types.
+     */
+    transform?: (raw: unknown) => unknown;
 }
 
 export class DynamicConfigPoller {
@@ -70,20 +75,29 @@ export class DynamicConfigPoller {
         return this.dynamicConfigSetup.interval || DYNAMIC_CONFIG_POLL_INTERVAL;
     }
 
-    private onSuccess = (response: {data: Record<string, boolean>}) => {
-        const {namespace} = this;
+    private onSuccess = (response: {data: unknown}) => {
+        const {namespace, dynamicConfigSetup} = this;
+
+        let result: unknown;
+        try {
+            result = dynamicConfigSetup.transform?.(response.data) ?? response.data;
+        } catch (error) {
+            this.ctx.logError('Dynamic config: transform failed', error, {namespace});
+            setTimeout(this.startPolling, this.getPollTimeout());
+            return;
+        }
 
         if (process.env.APP_DEBUG_DYNAMIC_CONFIG) {
             this.ctx.log('Dynamic config: fetch complete', {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                oldDynamicConfig: (this.ctx.dynamicConfig as Record<string, any>)[namespace],
-                fetchedDynamicConfig: response.data,
+                oldDynamicConfig: (this.ctx.dynamicConfig as Record<string, unknown>)[namespace],
+                fetchedDynamicConfig: result,
                 namespace,
             });
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (this.ctx.dynamicConfig as Record<string, any>)[namespace] = response.data;
+        (this.ctx.dynamicConfig as Record<string, unknown>)[namespace] = result;
 
         setTimeout(this.startPolling, this.getPollTimeout());
     };

--- a/src/lib/dynamic-config-poller.ts
+++ b/src/lib/dynamic-config-poller.ts
@@ -80,7 +80,9 @@ export class DynamicConfigPoller {
 
         let result: unknown;
         try {
-            result = dynamicConfigSetup.transform?.(response.data) ?? response.data;
+            result = dynamicConfigSetup.transform
+                ? dynamicConfigSetup.transform(response.data)
+                : response.data;
         } catch (error) {
             this.ctx.logError('Dynamic config: transform failed', error, {namespace});
             setTimeout(this.startPolling, this.getPollTimeout());
@@ -89,14 +91,12 @@ export class DynamicConfigPoller {
 
         if (process.env.APP_DEBUG_DYNAMIC_CONFIG) {
             this.ctx.log('Dynamic config: fetch complete', {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 oldDynamicConfig: (this.ctx.dynamicConfig as Record<string, unknown>)[namespace],
                 fetchedDynamicConfig: result,
                 namespace,
             });
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.ctx.dynamicConfig as Record<string, unknown>)[namespace] = result;
 
         setTimeout(this.startPolling, this.getPollTimeout());

--- a/src/tests/configuration/dynamic-config-poller.test.ts
+++ b/src/tests/configuration/dynamic-config-poller.test.ts
@@ -395,6 +395,98 @@ test('should combine static and dynamic headers correctly', async () => {
     );
 });
 
+test('should apply transform to raw response data before storing', async () => {
+    // ARRANGE
+    const mockAxiosGet = jest.fn().mockResolvedValue({
+        data: {featureA: true, featureB: false},
+    });
+
+    jest.doMock('axios', () => ({__esModule: true, default: {get: mockAxiosGet}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+
+    const transform = jest.fn((raw: {featureA: boolean; featureB: boolean}) => ({
+        featureA: raw.featureA ?? false,
+        featureB: raw.featureB ?? false,
+        featureC: false,
+    }));
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        url: 'https://example.com/config',
+        transform,
+    });
+
+    // ACT
+    await poller.startPolling();
+
+    // ASSERT
+    expect(transform).toHaveBeenCalledWith({featureA: true, featureB: false});
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual({
+        featureA: true,
+        featureB: false,
+        featureC: false,
+    });
+});
+
+test('should store raw data when transform is not provided', async () => {
+    // ARRANGE
+    const rawData = {featureA: true, featureB: false};
+    const mockAxiosGet = jest.fn().mockResolvedValue({data: rawData});
+
+    jest.doMock('axios', () => ({__esModule: true, default: {get: mockAxiosGet}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        url: 'https://example.com/config',
+    });
+
+    // ACT
+    await poller.startPolling();
+
+    // ASSERT
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual(rawData);
+});
+
+test('should log error and continue polling when transform throws', async () => {
+    // ARRANGE
+    const mockAxiosGet = jest.fn().mockResolvedValue({data: {featureA: true}});
+
+    jest.doMock('axios', () => ({__esModule: true, default: {get: mockAxiosGet}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+    const mockLogError = jest.fn();
+    ctx.logError = mockLogError;
+
+    const previousValue = {featureA: false};
+    (ctx.dynamicConfig as Record<string, unknown>)['test-namespace'] = previousValue;
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        url: 'https://example.com/config',
+        interval: MOCK_INTERVAL,
+        transform: () => {
+            throw new Error('transform error');
+        },
+    });
+    const spyOnStartPolling = jest.spyOn(poller, 'startPolling');
+
+    // ACT
+    await poller.startPolling();
+    await proceedWithTicksAndTimers(1);
+
+    // ASSERT
+    expect(mockLogError).toHaveBeenCalledWith(
+        'Dynamic config: transform failed',
+        expect.any(Error),
+        {namespace: 'test-namespace'},
+    );
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual(previousValue);
+    expect(spyOnStartPolling).toHaveBeenCalled();
+});
+
 test('should allow dynamic headers to override static headers', async () => {
     // ARRANGE
     const mockGetAuthHeaderValue = jest.fn().mockResolvedValue('Bearer dynamic-token');

--- a/src/tests/configuration/dynamic-config-poller.test.ts
+++ b/src/tests/configuration/dynamic-config-poller.test.ts
@@ -429,6 +429,27 @@ test('should apply transform to raw response data before storing', async () => {
     });
 });
 
+test('should store null when transform returns null', async () => {
+    // ARRANGE
+    const mockAxiosGet = jest.fn().mockResolvedValue({data: {featureA: true}});
+
+    jest.doMock('axios', () => ({__esModule: true, default: {get: mockAxiosGet}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        url: 'https://example.com/config',
+        transform: () => null,
+    });
+
+    // ACT
+    await poller.startPolling();
+
+    // ASSERT
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toBeNull();
+});
+
 test('should store raw data when transform is not provided', async () => {
     // ARRANGE
     const rawData = {featureA: true, featureB: false};


### PR DESCRIPTION
Add optional transform function to DynamicConfigSetup that is applied to the raw API response before the result is stored in dynamicConfig. This allows callers to set defaults, remap fields, or coerce types.
