### PR TITLE
feat: add custom fetch to dynamic config poller

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export {NodeKit} from './nodekit';
 export {AppContext} from './lib/context';
 export {AppConfig, AppContextParams, AppDynamicConfig, SpanKind} from './types';
 export {AppError} from './lib/app-error';
-export {DynamicConfigSetup} from './lib/dynamic-config-poller';
+export {DynamicConfigSetup, DynamicConfigFetcher} from './lib/dynamic-config-poller';
 export {NodeKitLogger} from './lib/logging';
 export {initTracing} from './lib/tracing/init-tracing';
 export * from './lib/public-consts';

--- a/src/lib/dynamic-config-poller.ts
+++ b/src/lib/dynamic-config-poller.ts
@@ -1,22 +1,39 @@
-import axios, {AxiosError, AxiosRequestConfig} from 'axios';
+import axios, {AxiosRequestConfig} from 'axios';
 
 import type {AppContext} from './context';
 
 const DYNAMIC_CONFIG_POLL_INTERVAL = 30000;
 
-export interface DynamicConfigSetup {
-    url: string;
+export type DynamicConfigFetcher = (ctx: AppContext) => Promise<unknown>;
+
+interface DynamicConfigBase {
     interval?: number;
-    /** static headers */
-    headers?: Record<string, string>;
-    /** dynamic headers */
-    dynamicHeaders?: Record<string, () => Promise<string>>;
     /**
      * Transform raw response data into the stored config value.
      * Use this to apply defaults, remap fields, or coerce types.
      */
     transform?: (raw: unknown) => unknown;
 }
+
+interface DynamicConfigWithUrl extends DynamicConfigBase {
+    /** Source URL fetched via the built-in HTTP GET. */
+    url: string;
+    /** Static headers. */
+    headers?: Record<string, string>;
+    /** Dynamic headers. */
+    dynamicHeaders?: Record<string, () => Promise<string>>;
+    fetch?: never;
+}
+
+interface DynamicConfigWithFetch extends DynamicConfigBase {
+    url?: never;
+    headers?: never;
+    dynamicHeaders?: never;
+    /** Custom fetcher for the raw config value. */
+    fetch: DynamicConfigFetcher;
+}
+
+export type DynamicConfigSetup = DynamicConfigWithUrl | DynamicConfigWithFetch;
 
 export class DynamicConfigPoller {
     ctx: AppContext;
@@ -37,6 +54,13 @@ export class DynamicConfigPoller {
             this.ctx.log('Dynamic config: fetching started', {
                 namespace,
             });
+        }
+
+        if (dynamicConfigSetup.fetch) {
+            return Promise.resolve(dynamicConfigSetup.fetch(this.ctx)).then(
+                (data) => this.onSuccess({data}),
+                this.onError,
+            );
         }
 
         const requestConfig: AxiosRequestConfig = {};
@@ -102,7 +126,7 @@ export class DynamicConfigPoller {
         setTimeout(this.startPolling, this.getPollTimeout());
     };
 
-    private onError = (error: AxiosError) => {
+    private onError = (error: unknown) => {
         const timeout = this.getPollTimeout();
         const {namespace} = this;
 

--- a/src/lib/dynamic-config-poller.ts
+++ b/src/lib/dynamic-config-poller.ts
@@ -57,10 +57,9 @@ export class DynamicConfigPoller {
         }
 
         if (dynamicConfigSetup.fetch) {
-            return Promise.resolve(dynamicConfigSetup.fetch(this.ctx)).then(
-                (data) => this.onSuccess({data}),
-                this.onError,
-            );
+            return Promise.resolve()
+                .then(() => dynamicConfigSetup.fetch(this.ctx))
+                .then((data) => this.onSuccess({data}), this.onError);
         }
 
         const requestConfig: AxiosRequestConfig = {};

--- a/src/tests/configuration/dynamic-config-poller.test.ts
+++ b/src/tests/configuration/dynamic-config-poller.test.ts
@@ -553,3 +553,89 @@ test('should allow dynamic headers to override static headers', async () => {
         },
     );
 });
+
+test('should use custom fetch and not call axios when `fetch` is provided', async () => {
+    // ARRANGE
+    const mockAxiosGet = jest.fn();
+    jest.doMock('axios', () => ({__esModule: true, default: {get: mockAxiosGet}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+
+    const fetcher = jest.fn().mockResolvedValue({gravity: 9.81});
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        fetch: fetcher,
+    });
+
+    // ACT
+    await poller.startPolling();
+
+    // ASSERT
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(ctx);
+    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual({
+        gravity: 9.81,
+    });
+});
+
+test('should apply transform to the value returned by a custom `fetch`', async () => {
+    // ARRANGE
+    jest.doMock('axios', () => ({__esModule: true, default: {get: jest.fn()}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+
+    const transform = jest.fn((raw: {featureA: boolean}) => ({
+        featureA: raw.featureA,
+        featureB: false,
+    }));
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        fetch: () => Promise.resolve({featureA: true}),
+        transform,
+    });
+
+    // ACT
+    await poller.startPolling();
+
+    // ASSERT
+    expect(transform).toHaveBeenCalledWith({featureA: true});
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual({
+        featureA: true,
+        featureB: false,
+    });
+});
+
+test('should keep previous value and reschedule when custom `fetch` rejects', async () => {
+    // ARRANGE
+    jest.doMock('axios', () => ({__esModule: true, default: {get: jest.fn()}}));
+
+    const {DynamicConfigPoller} = require('../../lib/dynamic-config-poller');
+    const ctx = createMockAppContext();
+    const mockLogError = jest.fn();
+    ctx.logError = mockLogError;
+
+    const previousValue = {featureA: false};
+    (ctx.dynamicConfig as Record<string, unknown>)['test-namespace'] = previousValue;
+
+    const poller = new DynamicConfigPoller(ctx, 'test-namespace', {
+        interval: MOCK_INTERVAL,
+        fetch: () => Promise.reject(new Error('fetch failed')),
+    });
+    const spyOnStartPolling = jest.spyOn(poller, 'startPolling');
+
+    // ACT
+    await poller.startPolling();
+    await proceedWithTicksAndTimers(1);
+
+    // ASSERT
+    expect(mockLogError).toHaveBeenCalledWith(
+        'Dynamic config: fetch failed',
+        expect.any(Error),
+        expect.objectContaining({namespace: 'test-namespace'}),
+    );
+    expect((ctx.dynamicConfig as Record<string, unknown>)['test-namespace']).toEqual(previousValue);
+    expect(spyOnStartPolling).toHaveBeenCalled();
+});


### PR DESCRIPTION
Adds a custom `fetch` option to `DynamicConfigPoller` as an alternative to the
built-in URL fetch. `DynamicConfigSetup` becomes a discriminated union:
`url` + `headers`/`dynamicHeaders` **or** `fetch: (ctx) => Promise<unknown>`
(mutually exclusive at compile time). Shared `transform`/`interval` and the
existing polling, error handling and rescheduling apply to both.

Lets the dynamic config be fetched from any custom source (for example S3 client), not just the built-in HTTP GET by URL.