### PR TITLE
chore: use nodenext resolution and es2022 target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,12 @@
   "extends": "@gravity-ui/tsconfig/tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
+    "target": "es2022",
+    "useDefineForClassFields": false,
     "outDir": "dist",
     "declaration": true,
-    "ignoreDeprecations": "6.0",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
The base `@gravity-ui/tsconfig` has been unmaintained since 2022 (a single published version, `1.0.0`) and still sets `moduleResolution: "node"` (node10), which TS 6 deprecates. We were silencing the warning with `ignoreDeprecations: "6.0"` rather than fixing it. `nodenext` fixes the cause and unblocks a future TS 7 upgrade, where node10 is removed entirely.

`target` also goes `es2017` → `es2022`, since `engines` already requires `node >= 20`:

```diff
-    var _a; const timeout = (_a = this.config.appShutdownTimeout) !== null && _a !== void 0 ? _a : ...
+    const timeout = this.config.appShutdownTimeout ?? this.config.nkDefaultShutdownTimeout;
```

**Note:** `target >= ES2022` turns on `useDefineForClassFields`, which changes `AppError` at runtime — its optional `code`/`details`/`debug` fields would become own properties set to `undefined`:

```
before: Object.keys(new AppError('boom')) → []                          'code' in e → false
after:  Object.keys(new AppError('boom')) → ["code","details","debug"]  'code' in e → true
```

That's breaking for anyone serializing our errors, so `useDefineForClassFields` is explicitly pinned to `false`.
