### PR TITLE
feat: log when SIGTERM/SIGINT is received

### DIFF
--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -159,6 +159,8 @@ export class NodeKit {
         const handleSignal: ShutdownHandler = (signal) => {
             signals.forEach((signalName) => process.off(signalName, handleSignal));
 
+            this.ctx.log('Received shutdown signal', {signal});
+
             let code = 0;
 
             const promises = this.shutdownHandlers.map((handler) => {

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -187,6 +187,7 @@ export class NodeKit {
                 if (timeoutId) {
                     clearTimeout(timeoutId);
                 }
+
                 this.ctx.log('Shutdown signal handled', {signal, code});
                 this.ctx.end();
                 process.exit(code);

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -187,6 +187,7 @@ export class NodeKit {
                 if (timeoutId) {
                     clearTimeout(timeoutId);
                 }
+                this.ctx.log('Shutdown signal handled', {signal, code});
                 this.ctx.end();
                 process.exit(code);
             });

--- a/src/tests/shutdown-timeout.test.ts
+++ b/src/tests/shutdown-timeout.test.ts
@@ -27,11 +27,19 @@ describe('shutdown timeout configuration', () => {
 
         await jest.advanceTimersByTimeAsync(0);
 
-        const log = JSON.parse(logger.write.mock.calls[0]?.[0] || '{}');
-        expect(log).toMatchObject({
+        const received = JSON.parse(logger.write.mock.calls[0]?.[0] || '{}');
+        expect(received).toMatchObject({
             msg: 'Received shutdown signal',
             level: 30,
             signal: 'SIGTERM',
+        });
+
+        const handled = JSON.parse(logger.write.mock.calls.at(-1)?.[0] || '{}');
+        expect(handled).toMatchObject({
+            msg: 'Shutdown signal handled',
+            level: 30,
+            signal: 'SIGTERM',
+            code: 0,
         });
         expect(exitSpy).toHaveBeenCalledWith(0);
     });

--- a/src/tests/shutdown-timeout.test.ts
+++ b/src/tests/shutdown-timeout.test.ts
@@ -18,6 +18,24 @@ describe('shutdown timeout configuration', () => {
         jest.useRealTimers();
     });
 
+    test('logs when SIGTERM is received', async () => {
+        jest.useFakeTimers();
+
+        const {logger} = setupNodeKit({appShutdownTimeout: 1000});
+
+        process.emit('SIGTERM', 'SIGTERM');
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        const log = JSON.parse(logger.write.mock.calls[0]?.[0] || '{}');
+        expect(log).toMatchObject({
+            msg: 'Received shutdown signal',
+            level: 30,
+            signal: 'SIGTERM',
+        });
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
     test('appShutdownTimeout takes priority over nkDefaultShutdownTimeout', () => {
         jest.useFakeTimers();
 


### PR DESCRIPTION
## Summary
- Log an info message when a shutdown signal (`SIGTERM` / `SIGINT`) is received, before shutdown handlers run
- Helps observe pod drain / graceful shutdown during deploys
