### PR TITLE
feat: add log record filtering

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -99,6 +99,23 @@ childCtx.log('Waiting for response to prepare');
 
 You can override default logs destination (stdout) with `appLoggingDestination` option which accepts [pino.Destination](https://github.com/pinojs/pino/blob/master/docs/api.md#destination). It allows to implement custom formatters for logs as well as custom transports for them. Currently, this option only works if devMode is set to false. If you have an usecase when you need this option alongside enabled dev mode, feel free to open an issue.
 
+### Filtering logs
+
+Use `appLoggingFilter` to suppress selected log records before they reach the logger or destination. The filter runs synchronously and receives the log level, structured extra data and the final message, including context prefixes and postfixes. Return `true` to keep the record or `false` to suppress it:
+
+```typescript
+const ignoredMessages = [/healthcheck$/, /request started$/];
+
+const nodeKit = new NodeKit({
+  config: {
+    appLoggingFilter: ({level, message}) =>
+      level !== 'info' || ignoredMessages.every((pattern) => !pattern.test(message)),
+  },
+});
+```
+
+The filter applies to both the default logger and `appLogger`. It only suppresses logger output: tracing events and span status are not affected.
+
 ## Distributed tracing
 
 NodeKit Contexts are integrated with [Opentelemetry tracing](https://opentelemetry.io/). If tracing is enabled in your application, each created context (except the root one) will create span alongside it. Logs are working too: they're added to spans as events.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,6 @@ export {AppContext} from './lib/context';
 export {AppConfig, AppContextParams, AppDynamicConfig, SpanKind} from './types';
 export {AppError} from './lib/app-error';
 export {DynamicConfigSetup, DynamicConfigFetcher} from './lib/dynamic-config-poller';
-export {NodeKitLogger} from './lib/logging';
+export {AppLoggingFilter, NodeKitLogger} from './lib/logging';
 export {initTracing} from './lib/tracing/init-tracing';
 export * from './lib/public-consts';

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -18,6 +18,48 @@ export interface NodeKitLogger {
     debug(extra: Dict | undefined, message: string): void;
 }
 
+type NodeKitLogLevel = keyof NodeKitLogger;
+
+export type AppLoggingFilter = (
+    record: Readonly<{
+        level: NodeKitLogLevel;
+        message: string;
+        extra?: Dict;
+    }>,
+) => boolean;
+
+export function withLoggingFilter(logger: NodeKitLogger, filter?: AppLoggingFilter): NodeKitLogger {
+    if (!filter) {
+        return logger;
+    }
+
+    const wrap = (level: NodeKitLogLevel) => {
+        return (msgOrExtra: string | Dict | undefined, message?: string) => {
+            const isMessageOnly = typeof msgOrExtra === 'string';
+            const logMessage = isMessageOnly ? msgOrExtra : (message as string);
+            const extra = isMessageOnly ? undefined : msgOrExtra;
+
+            if (!filter({level, message: logMessage, extra})) {
+                return;
+            }
+
+            if (isMessageOnly) {
+                logger[level](logMessage);
+            } else {
+                logger[level](extra, logMessage);
+            }
+        };
+    };
+
+    return {
+        trace: wrap('trace'),
+        debug: wrap('debug'),
+        info: wrap('info'),
+        warn: wrap('warn'),
+        error: wrap('error'),
+    };
+}
+
 export class PinoLogger implements NodeKitLogger {
     private logger: pino.Logger;
 

--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -4,7 +4,7 @@ import {NODEKIT_BASE_CONFIG} from './lib/base-config';
 import {AppContext} from './lib/context';
 import {DynamicConfigPoller, DynamicConfigSetup} from './lib/dynamic-config-poller';
 import {loadFileConfigs} from './lib/file-configs';
-import {NodeKitLogger, initLogger} from './lib/logging';
+import {NodeKitLogger, initLogger, withLoggingFilter} from './lib/logging';
 import {prepareClickhouseClient} from './lib/telemetry/clickhouse';
 import {initTracing} from './lib/tracing/init-tracing';
 import {isTrueEnvValue} from './lib/utils/is-true-env';
@@ -109,6 +109,7 @@ export class NodeKit {
                 level: this.config.appLoggingLevel,
             });
         }
+        this.logger = withLoggingFilter(this.logger, this.config.appLoggingFilter);
 
         this.utils = {
             ...prepareRedacters(this.config, appDevMode),

--- a/src/tests/logging.test.ts
+++ b/src/tests/logging.test.ts
@@ -1,4 +1,6 @@
-import {NodeKit, NodeKitLogger} from '..';
+import {SpanStatusCode} from '@opentelemetry/api';
+import {core, tracing} from '@opentelemetry/sdk-node';
+import {AppLoggingFilter, NodeKit, NodeKitLogger} from '..';
 import {Dict} from '../types';
 
 const genRandomId = (length = 16) => {
@@ -14,6 +16,57 @@ const setupNodeKit = () => {
 
     return {nodekit, logger};
 };
+
+test('filter logging without filtering tracing', async () => {
+    const logger = {write: jest.fn()};
+    let exportSpans!: (spans: tracing.ReadableSpan[]) => void;
+    const exportedSpans = new Promise<tracing.ReadableSpan[]>((resolve) => {
+        exportSpans = resolve;
+    });
+    const spanExporter: tracing.SpanExporter = {
+        export(spans, callback) {
+            exportSpans(spans);
+            callback({code: core.ExportResultCode.SUCCESS});
+        },
+        shutdown: () => Promise.resolve(),
+    };
+    const previousScheduleDelay = process.env.OTEL_BSP_SCHEDULE_DELAY;
+    process.env.OTEL_BSP_SCHEDULE_DELAY = '1';
+    let nodekit: NodeKit;
+    try {
+        nodekit = new NodeKit({
+            config: {
+                appLoggingDestination: logger,
+                appLoggingFilter: () => false,
+                appTracingEnabled: true,
+                appTracingSpanExporter: spanExporter,
+            },
+        });
+    } finally {
+        if (previousScheduleDelay === undefined) {
+            delete process.env.OTEL_BSP_SCHEDULE_DELAY;
+        } else {
+            process.env.OTEL_BSP_SCHEDULE_DELAY = previousScheduleDelay;
+        }
+    }
+    const ctx = nodekit.ctx.create('test_ctx');
+
+    ctx.logError('ignored');
+    ctx.end();
+
+    expect(logger.write).not.toHaveBeenCalled();
+    const [span] = await exportedSpans;
+    expect(span.status).toEqual({
+        code: SpanStatusCode.ERROR,
+        message: 'ignored',
+    });
+    expect(span.events).toEqual([
+        expect.objectContaining({
+            name: 'ignored',
+            attributes: expect.objectContaining({event: 'ignored'}),
+        }),
+    ]);
+});
 
 test('check base logging system', () => {
     const {nodekit, logger} = setupNodeKit();
@@ -174,6 +227,33 @@ test('check logging spanId and traceId', () => {
     });
 });
 
+test('filter logging', () => {
+    const logger = {write: jest.fn()};
+    const records: Parameters<AppLoggingFilter>[0][] = [];
+    const nodekit = new NodeKit({
+        config: {
+            appLoggingDestination: logger,
+            appLoggingFilter: (record) => {
+                records.push(record);
+                return record.message !== '[test_ctx] ignored';
+            },
+        },
+    });
+    const ctx = nodekit.ctx.create('test_ctx');
+
+    ctx.log('ignored', {foo: 'bar'});
+
+    expect(records).toEqual([{level: 'info', message: '[test_ctx] ignored', extra: {foo: 'bar'}}]);
+    expect(logger.write).not.toHaveBeenCalled();
+
+    ctx.log('visible');
+
+    expect(JSON.parse(logger.write.mock.lastCall?.pop() || '{}')).toMatchObject({
+        level: 30,
+        msg: '[test_ctx] visible',
+    });
+});
+
 test('logging with a custom logger', () => {
     const warnLog = jest.fn();
     const debugLog = jest.fn();
@@ -202,6 +282,7 @@ test('logging with a custom logger', () => {
     const nodekit = new NodeKit({
         config: {
             appLogger: customLogger,
+            appLoggingFilter: ({message}) => message !== '[test_ctx] filtered',
         },
     });
 
@@ -234,4 +315,7 @@ test('logging with a custom logger', () => {
         },
         '[test_ctx] warnLog message',
     );
+
+    ctx.log('filtered');
+    expect(infoLog).toHaveBeenCalledTimes(1);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type pino from 'pino';
 import type {NodeSDKConfiguration} from '@opentelemetry/sdk-node';
 
 import {REQUEST_ID_PARAM_NAME, USER_ID_PARAM_NAME, USER_LANGUAGE_PARAM_NAME} from './lib/consts';
-import type {LoggingLevel, NodeKitLogger} from './lib/logging';
+import type {AppLoggingFilter, LoggingLevel, NodeKitLogger} from './lib/logging';
 
 export interface AppConfig {
     appName?: string;
@@ -33,6 +33,12 @@ export interface AppConfig {
 
     appLoggingDestination?: pino.DestinationStream;
     appLoggingLevel?: LoggingLevel;
+    /**
+     * Synchronously decides whether a log record is forwarded to the logger.
+     * Returning false suppresses logger output without affecting tracing events or span status.
+     * @default undefined
+     */
+    appLoggingFilter?: AppLoggingFilter;
     appLogger?: NodeKitLogger;
 
     appTracingEnabled?: boolean;


### PR DESCRIPTION
## Summary

- add a synchronous `appLoggingFilter` predicate over structured log records
- apply filtering to both the default logger and `appLogger` before serialization and destination writes
- document regex-based filtering while preserving tracing events and span status

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm test` (15 suites, 120 tests)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.
