### PR TITLE
fix: suppress dotenv startup banner by default

### DIFF
--- a/src/nodekit.ts
+++ b/src/nodekit.ts
@@ -65,7 +65,10 @@ export class NodeKit {
 
     constructor(options: InitOptions = {}) {
         if (!options.disableDotEnv) {
-            dotenv.config(options.envFilePath ? {path: options.envFilePath} : undefined);
+            dotenv.config({
+                quiet: true,
+                ...(options.envFilePath ? {path: options.envFilePath} : {}),
+            });
         }
 
         const appInstallation = process.env.APP_INSTALLATION;

--- a/src/tests/dotenv.test.ts
+++ b/src/tests/dotenv.test.ts
@@ -10,10 +10,10 @@ beforeEach(() => {
 });
 
 describe('dotenv integration', () => {
-    test('should call dotenv.config by default', () => {
+    test('should call dotenv.config quietly by default', () => {
         const nodekit = new NodeKit({config: {appTracingEnabled: false}});
         expect(mockedDotenv.config).toHaveBeenCalledTimes(1);
-        expect(mockedDotenv.config).toHaveBeenCalledWith(undefined);
+        expect(mockedDotenv.config).toHaveBeenCalledWith({quiet: true});
         expect(nodekit.config).toBeDefined();
     });
 
@@ -28,7 +28,7 @@ describe('dotenv integration', () => {
             envFilePath: '/custom/.env',
             config: {appTracingEnabled: false},
         });
-        expect(mockedDotenv.config).toHaveBeenCalledWith({path: '/custom/.env'});
+        expect(mockedDotenv.config).toHaveBeenCalledWith({quiet: true, path: '/custom/.env'});
         expect(nodekit.config).toBeDefined();
     });
 });


### PR DESCRIPTION
Pass `quiet: true` when NodeKit initializes dotenv so its default startup banner and promotional tips no longer appear in application logs. Apply the option for both the default `.env` file and custom `envFilePath` values, while preserving `disableDotEnv` behavior and dotenv's environment-controlled overrides.

Update the existing integration tests to assert quiet loading for both paths.

Validation: `npm test` (15 suites, 118 tests), `npm run lint`, and `npm run typecheck` pass on Node.js 24.12.0.

Complete dependency removal and a Node.js support update are tracked separately in #154 for the next major.
